### PR TITLE
feat: add opacity tokens. add typography font familiy import

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,15 @@
+{
+    "compilerOptions": {
+        "module": "ESNext",
+        "moduleResolution": "Bundler",
+        "target": "ES2020",
+        "jsx": "react",
+        "allowImportingTsExtensions": true,
+        "strictNullChecks": false,
+        "strictFunctionTypes": true
+    },
+    "exclude": [
+        "node_modules",
+        "**/node_modules/*"
+    ]
+}

--- a/src/utils/tokens/_opacity.scss
+++ b/src/utils/tokens/_opacity.scss
@@ -1,0 +1,5 @@
+$opacity: (
+    'light': 0.2,
+    'medium': 0.5,
+    'dark': 0.8
+)

--- a/src/utils/tokens/_typography.scss
+++ b/src/utils/tokens/_typography.scss
@@ -1,99 +1,149 @@
+@import url('https://fonts.googleapis.com/css2?family=Nunito+Sans:ital,opsz,wght@0,6..12,200..1000;1,6..12,200..1000&display=swap');
+
+@mixin font-family-pattern {
+    font-family: "Nunito Sans", sans-serif;
+    font-optical-sizing: auto;
+    font-variation-settings:
+    "wdth" 100,
+    "YTLC" 500;
+}
+
 @mixin typography-title-1 {
+    @include font-family-pattern;
+
     font-size: 48px;
     font-weight: 700;
 }
 
 @mixin typography-title-2 {
+    @include font-family-pattern;
+
     font-size: 40px;
     font-weight: 700;
 }
 
 @mixin typography-title-3 {
+    @include font-family-pattern;
+
     font-size: 32px;
     font-weight: 700;
 }
 
 @mixin typography-title-4 {
+    @include font-family-pattern;
+
     font-size: 28px;
     font-weight: 700;
 }
 
 @mixin typography-title-5 {
+    @include font-family-pattern;
+
     font-size: 24px;
     font-weight: 700;
 }
 
 @mixin typography-title-6 {
+    @include font-family-pattern;
+
     font-size: 20px;
     font-weight: 700;
 }
 
 @mixin typography-body-1 {
+    @include font-family-pattern;
+
     font-size: 18px;
     font-weight: 400;
 }
 
 @mixin typography-body-2 {
+    @include font-family-pattern;
+
     font-size: 16px;
     font-weight: 400;
 }
 
 @mixin typography-body-3 {
+    @include font-family-pattern;
+
     font-size: 14px;
     font-weight: 400;
 }
 
 @mixin typography-body-1-highlight {
+    @include font-family-pattern;
+
     font-size: 18px;
     font-weight: 600;
 }
 
 @mixin typography-body-2-highlight {
+    @include font-family-pattern;
+
     font-size: 16px;
     font-weight: 600;
 }
 
 @mixin typography-body-3-highlight {
+    @include font-family-pattern;
+
     font-size: 14px;
     font-weight: 600;
 }
 
 @mixin typography-label-1 {
+    @include font-family-pattern;
+
     font-size: 16px;
     font-weight: 600;
 }
 
 @mixin typography-label-1 {
+    @include font-family-pattern;
+
     font-size: 16px;
     font-weight: 600;
 }
 
 @mixin typography-label-2 {
+    @include font-family-pattern;
+
     font-size: 14px;
     font-weight: 600;
 }
 
 @mixin typography-label-3 {
+    @include font-family-pattern;
+
     font-size: 12px;
     font-weight: 600;
 }
 
 @mixin typography-label-4 {
+    @include font-family-pattern;
+
     font-size: 10px;
     font-weight: 600;
 }
 
 @mixin typography-button-small {
+    @include font-family-pattern;
+
     font-size: 14px;
     font-weight: 600;
 }
 
 @mixin typography-button-medium {
+    @include font-family-pattern;
+
     font-size: 18px;
     font-weight: 600;
 }
 
 @mixin typography-button-large {
+    @include font-family-pattern;
+
     font-size: 20px;
     font-weight: 600;
 }

--- a/src/utils/tokens/tokens.scss
+++ b/src/utils/tokens/tokens.scss
@@ -1,5 +1,6 @@
 @import './colors';
 @import './borders';
 @import './shadows';
+@import './opacity';
 @import './spacing';
 @import './typography';


### PR DESCRIPTION
# Mudanças

- Adicionado arquivo de token com valores de opacity
- Adicionada font-familiy e import de font de google fonts
- Adicionado `jsconfig.json`
- Criação de componente básico de exemplo
- Adição de suporte a scss no arquivo de configuração do vite