### PR TITLE
feat/docs: add blush button docs. add full button style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+*storybook.log

--- a/src/components/blush-button/blush-button.scss
+++ b/src/components/blush-button/blush-button.scss
@@ -3,7 +3,12 @@
     border-radius: map-get($border-radius, 'small');
     display: flex;
     align-items: center;
+    justify-content: center;
     transition: all 400ms linear;
+
+    &.full {
+        width: 100%;
+    }
 
     &:hover, &:active {
         &:not([disabled]) {

--- a/src/components/blush-button/blush-button.stories.js
+++ b/src/components/blush-button/blush-button.stories.js
@@ -1,0 +1,198 @@
+import { fn } from '@storybook/test';
+import BlushButton from './blush-button.vue';
+
+export default {
+  title: 'BLUSH/blush-button',
+  component: BlushButton,
+  tags: ['autodocs'],
+  parameters: {
+    componentSubtitle: 'Componente de botão com uma lista de opções de cores, estilos e tamanhos.',
+  },
+  argTypes: {
+    id: {
+        control: {
+            type: 'text'
+        },
+        description: 'ID do Botão',
+        table: {
+            type: {
+                summary: 'string'
+            }
+        }
+    },
+    name: {
+        control: {
+            type: 'text'
+        },
+        description: 'Nome do Botão',
+        table: {
+            type: {
+                summary: 'string'
+            }
+        }
+    },
+    type: {
+        control: {
+            type: 'select'
+        },
+        table: {
+            type: {
+                summary: 'string'
+            }
+        },
+        description: 'Tipo do botão',
+        options: ['button', 'submit', 'reset'],
+    },
+    size: {
+        control: {
+            type: 'select'
+        },
+        table: {
+            type: {
+                summary: 'string'
+            }
+        },
+        description: 'Tamanho do botão',
+        options: ['small', 'medium', 'large'],
+    },
+    label: {
+        control: {
+            type: 'text'
+        },
+        description: 'Label do Botão',
+        table: {
+            type: {
+                summary: 'string'
+            }
+        }
+    },
+    variant: {
+        control: {
+            type: 'select'
+        },
+        table: {
+            type: {
+                summary: 'string'
+            }
+        },
+        description: 'Estilo do botão',
+        options: ['primary', 'primary-outline', 'primary-ghost',
+        'accent', 'accent-outline', 'accent-ghost',
+        'success', 'success-outline', 'success-ghost',
+        'warning', 'warning-outline', 'warning-ghost',
+        'danger', 'danger-outline', 'danger-ghost',
+        'neutral', 'neutral-outline', 'neutral-ghost'],
+    },
+    disabled: {
+        control: {
+            type: 'boolean'
+        },
+        description: 'Define se o botão está desabilitado ou não.',
+        table: {
+            type: {
+                summary: 'boolean'
+            }
+        }
+    },
+    autofocus: {
+        control: {
+            type: 'boolean'
+        },
+        description: 'Define se o botão tem autofocus ou não.',
+        table: {
+            type: {
+                summary: 'boolean'
+            }
+        }
+    },
+    block: {
+        control: {
+            type: 'boolean'
+        },
+        description: 'Define se o botão ocupará 100% do tamanho disponível ou seguirá tamanho do conteúdo.',
+        table: {
+            type: {
+                summary: 'boolean'
+            }
+        }
+    },
+  },
+  // Use `fn` to spy on the onClick arg, which will appear in the actions panel once invoked: https://storybook.js.org/docs/essentials/actions#action-args
+  args: {
+    onClick: fn()
+  },
+};
+
+const generalArgs = {
+    id: 'button-id',
+    name: 'button-name',
+    type: 'button',
+    label: 'Button',
+    size: 'medium',
+    variant: 'primary',
+    disabled: false,
+    autofocus: false,
+    block: false,
+}
+
+export const Primary = {
+  args: {
+    ...generalArgs,
+  },
+};
+
+export const Accent = {
+  args: {
+    ...generalArgs,
+    variant: 'accent',
+  },
+};
+
+export const Success = {
+    args: {
+      ...generalArgs,
+      variant: 'success',
+    },
+};
+
+export const Warning = {
+    args: {
+      ...generalArgs,
+      variant: 'warning',
+    },
+};
+
+export const Danger = {
+    args: {
+      ...generalArgs,
+      variant: 'danger',
+    },
+};
+
+export const Small = {
+    args: {
+      ...generalArgs,
+      size: 'small',
+    },
+};
+
+export const Medium = {
+    args: {
+      ...generalArgs,
+      size: 'medium',
+    },
+};
+
+export const Large = {
+    args: {
+      ...generalArgs,
+      size: 'large',
+    },
+};
+
+export const Disabled = {
+    args: {
+      ...generalArgs,
+      disabled: true,
+    },
+};


### PR DESCRIPTION
# Mudanças

- Adicionado arquivo de storie do `blush-button` para documentação com storybook com props e exemplos;
- Adicionado estilo quando botão for setado com a prop `block` (width 100%)
